### PR TITLE
Version 0.0.2 bump and CHANGELOG update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.0.2 - 2022-09-03 - More detail, across the zones
+
+* Support tracking records across other zones in the same run
+* Include more information about why things matched in the case of
+  wildcards/cnames etc.
+
 ## v0.0.1 - 2022-01-09 - Moving
 
 #### Nothworthy Changes

--- a/octodns_etchosts/__init__.py
+++ b/octodns_etchosts/__init__.py
@@ -10,7 +10,7 @@ import re
 
 from octodns.provider.base import BaseProvider
 
-__VERSION__ = '0.0.1'
+__VERSION__ = '0.0.2'
 
 
 def _wildcard_match(fqdn, wildcards):


### PR DESCRIPTION
## v0.0.2 - 2022-09-03 - More detail, across the zones

* Support tracking records across other zones in the same run
* Include more information about why things matched in the case of
  wildcards/cnames etc.