### PR TITLE
Sort by num, sorting by the whole record can result in errors

### DIFF
--- a/octodns_etchosts/__init__.py
+++ b/octodns_etchosts/__init__.py
@@ -173,7 +173,7 @@ class EtcHostsProvider(BaseProvider):
                 records.sort(key=lambda r: r._type)
 
             # Sort wildcards longest first so that we match most specific
-            self._wildcards.sort()
+            self._wildcards.sort(key=lambda w: w[0:2])
 
             self._write()
 


### PR DESCRIPTION
Will get errors like:
>           self._wildcards.sort()
E           TypeError: '<' not supported between instances of 're.Pattern' and 're.Pattern'

octodns_etchosts/__init__.py:179: TypeError