### PR TITLE
Version 1.0.0 version bump & changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v1.0.0 - 2024-??-?? - ???
+## v1.0.0 - 2025-05-04 - Long overdue 1.0
 
 * Address pending octoDNS 2.x deprecations, require minimum of 1.5.x
 

--- a/octodns_etchosts/__init__.py
+++ b/octodns_etchosts/__init__.py
@@ -11,7 +11,7 @@ from os.path import isdir
 from octodns.provider.base import BaseProvider
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '0.0.2'
+__version__ = __VERSION__ = '1.0.0'
 
 
 def _wildcard_match(fqdn, wildcards):


### PR DESCRIPTION
## v1.0.0 - 2025-05-04 - Long overdue 1.0

* Address pending octoDNS 2.x deprecations, require minimum of 1.5.x