### PR TITLE
Add 'remove_trailing_dots' option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.?.0 - 2025-??-?? - ???
+
+* Omit trailing . from entries to match the requirement that names end in an
+  alphanumeric character, per the manpage/spec. Previous behavior of trailing
+  dots is available with remove_trailing_dots=False
+
 ## v1.0.0 - 2025-05-04 - Long overdue 1.0
 
 * Address pending octoDNS 2.x deprecations, require minimum of 1.5.x

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ providers:
     class: octodns_etchosts.EtcHostsProvider
     # The output directory for the hosts file <zone>.hosts
     directory: ./hosts
-    # Remove trailing dots of zone names (e.g. example.com. => example.com)
+    # Remove trailing dots of zone names (e.g. example.com. => example.com) (optional)
     # Avoids problems with certain DNS providers, as the host file format requires an alphanumeric character to be the final character in a hostname.
     # Default: True
-    remove_trailing_dots: True
+    #remove_trailing_dots: True
 ```
 
 ### Support Information

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ providers:
     class: octodns_etchosts.EtcHostsProvider
     # The output directory for the hosts file <zone>.hosts
     directory: ./hosts
+    # Remove trailing dots of zone names (e.g. example.com. => example.com)
+    # Avoids problems with certain DNS providers, as the host file format requires an alphanumeric character to be the final character in a hostname.
+    # Default: False
+    remove_trailing_dots: False
 ```
 
 ### Support Information

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ providers:
     directory: ./hosts
     # Remove trailing dots of zone names (e.g. example.com. => example.com)
     # Avoids problems with certain DNS providers, as the host file format requires an alphanumeric character to be the final character in a hostname.
-    # Default: False
-    remove_trailing_dots: False
+    # Default: True
+    remove_trailing_dots: True
 ```
 
 ### Support Information

--- a/octodns_etchosts/__init__.py
+++ b/octodns_etchosts/__init__.py
@@ -27,7 +27,7 @@ class EtcHostsProvider(BaseProvider):
     SUPPORTS = set(('A', 'AAAA', 'ALIAS', 'CNAME'))
 
     def __init__(
-        self, id, directory, remove_trailing_dots=False, *args, **kwargs
+        self, id, directory, remove_trailing_dots=True, *args, **kwargs
     ):
         self.log = getLogger(f'EtcHostsProvider[{id}]')
         self.log.debug('__init__: id=%s, directory=%s', id, directory)

--- a/tests/test_octodns_provider_etchosts.py
+++ b/tests/test_octodns_provider_etchosts.py
@@ -93,7 +93,7 @@ class TestEtcHostsProvider(TestCase):
             # Add some subdirs to make sure that it can create them
             directory = path.join(td.dirname, 'sub', 'dir')
             hosts_file = path.join(directory, 'unit.tests.hosts')
-            target = EtcHostsProvider('test', directory)
+            target = EtcHostsProvider('test', directory, False)
 
             # We add everything
             plan = target.plan(zone)
@@ -148,7 +148,7 @@ class TestEtcHostsProvider(TestCase):
             # Add some subdirs to make sure that it can create them
             directory = path.join(td.dirname, 'hosts')
             hosts_file = path.join(directory, 'unit.tests.hosts')
-            target = EtcHostsProvider('test', directory)
+            target = EtcHostsProvider('test', directory, False)
 
             # We add everything
             plan = target.plan(zone)
@@ -217,7 +217,7 @@ class TestEtcHostsProvider(TestCase):
             # Add some subdirs to make sure that it can create them
             directory = path.join(td.dirname, 'hosts')
             hosts_file = path.join(directory, 'unit.tests.hosts')
-            target = EtcHostsProvider('test', directory)
+            target = EtcHostsProvider('test', directory, False)
 
             # We add everything
             plan = target.plan(zone)

--- a/tests/test_octodns_provider_etchosts.py
+++ b/tests/test_octodns_provider_etchosts.py
@@ -354,3 +354,74 @@ class TestEtcHostsProvider(TestCase):
             # Now actually do it
             self.assertEqual(len(zone.records), target.apply(plan))
             self.assertTrue(isfile(hosts_file))
+
+    def test_remove_trailing_dots(self):
+        zone = Zone('unit.tests.', [])
+
+        record = Record.new(
+            zone, '', {'ttl': 60, 'type': 'ALIAS', 'value': 'www.unit.tests.'}
+        )
+        zone.add_record(record)
+
+        record = Record.new(
+            zone,
+            'www',
+            {'ttl': 60, 'type': 'AAAA', 'value': '2001:4860:4860::8888'},
+        )
+        zone.add_record(record)
+        record = Record.new(
+            zone,
+            'www',
+            {'ttl': 60, 'type': 'A', 'values': ['1.1.1.1', '2.2.2.2']},
+        )
+        zone.add_record(record)
+
+        record = record.new(
+            zone,
+            'v6',
+            {'ttl': 60, 'type': 'AAAA', 'value': '2001:4860:4860::8844'},
+        )
+        zone.add_record(record)
+
+        record = record.new(
+            zone,
+            'start',
+            {'ttl': 60, 'type': 'CNAME', 'value': 'middle.unit.tests.'},
+        )
+        zone.add_record(record)
+        record = record.new(
+            zone, 'middle', {'ttl': 60, 'type': 'CNAME', 'value': 'unit.tests.'}
+        )
+        zone.add_record(record)
+
+        with TemporaryDirectory() as td:
+            # Add some subdirs to make sure that it can create them
+            directory = path.join(td.dirname, 'sub', 'dir')
+            hosts_file = path.join(directory, 'unit.tests.hosts')
+            target = EtcHostsProvider('test', directory, True)
+
+            # We add everything
+            plan = target.plan(zone)
+            self.assertEqual(len(zone.records), len(plan.changes))
+            self.assertFalse(isfile(hosts_file))
+
+            # Now actually do it
+            self.assertEqual(len(zone.records), target.apply(plan))
+            self.assertTrue(isfile(hosts_file))
+
+            with open(hosts_file) as fh:
+                data = fh.read()
+                # v6
+                self.assertTrue('2001:4860:4860::8844\tv6.unit.tests\n' in data)
+                # www
+                self.assertTrue('1.1.1.1\twww.unit.tests\n' in data)
+                # root ALIAS
+                self.assertTrue('# unit.tests. -> www.unit.tests.\n' in data)
+                self.assertTrue('1.1.1.1\tunit.tests\n' in data)
+
+                self.assertTrue(
+                    '# start.unit.tests. -> middle.unit.tests.\n' in data
+                )
+                self.assertTrue('# middle.unit.tests. -> unit.tests.\n' in data)
+                self.assertTrue('# unit.tests. -> www.unit.tests.\n' in data)
+                self.assertTrue('1.1.1.1	start.unit.tests\n' in data)


### PR DESCRIPTION
The host file format requires that hostnames end with an alphanumeric character ([Manpage](https://man7.org/linux/man-pages/man5/hosts.5.html)). However, OctoDNS zones require a trailing dot, which results in the /etc/hosts file not being conform to the specification.
This can lead to problems with DNS providers using the host file. For example, [blocky](https://github.com/0xERR0R/blocky) does not accept the format with trailing dots in the hostname.

Therefore, I have added an option 'remove_trailing_dots', which removes the trailing dot from the generated /etc/hosts file.