### PR TITLE
Version 1.1.0 bump & changelog update

### DIFF
--- a/.changelog/05f3b5dc965240e7a07f71522e390fd9.md
+++ b/.changelog/05f3b5dc965240e7a07f71522e390fd9.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Use new [changelet](https://github.com/octodns/changelet) tooling

--- a/.changelog/0c766cb99c8a419aa8af6396b7ee56aa.md
+++ b/.changelog/0c766cb99c8a419aa8af6396b7ee56aa.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Run changelog check during pre-commit

--- a/.changelog/18c3e931f38542f9ab90ff4a880cb860.md
+++ b/.changelog/18c3e931f38542f9ab90ff4a880cb860.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Use script/common.sh in script/update-requirements

--- a/.changelog/3d427d8390b0484fbf3c75b7c0438cf6.md
+++ b/.changelog/3d427d8390b0484fbf3c75b7c0438cf6.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/41bc3f8da3c84ca9a734d0be96c589c5.md
+++ b/.changelog/41bc3f8da3c84ca9a734d0be96c589c5.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update scripts to use common.sh

--- a/.changelog/7f722301e34140f7bbf0b4126709342d.md
+++ b/.changelog/7f722301e34140f7bbf0b4126709342d.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Add JSON coverage report format

--- a/.changelog/8d5ac9f8740a4cdd9dde916a17e8ffef.md
+++ b/.changelog/8d5ac9f8740a4cdd9dde916a17e8ffef.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Switch to proviso for requirements.txt management

--- a/.changelog/ad7b60c42d6b4636a2abf72cac010ae5.md
+++ b/.changelog/ad7b60c42d6b4636a2abf72cac010ae5.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Pull in the latest template changes

--- a/.changelog/b6f273b0dab84d1684b0a2073e72889f.md
+++ b/.changelog/b6f273b0dab84d1684b0a2073e72889f.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Omit trailing . from entries to match the requirement that names end in an alphanumeric character, per the manpage/spec. Previous behavior of trailing dots is available with remove_trailing_dots=False

--- a/.changelog/c7d8ddf0d4a045c38d45002b8ad93a32.md
+++ b/.changelog/c7d8ddf0d4a045c38d45002b8ad93a32.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements.txt

--- a/.changelog/cb0c0117bc694a32a01d5ea5578ac967.md
+++ b/.changelog/cb0c0117bc694a32a01d5ea5578ac967.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements*.txt

--- a/.changelog/e83abffbd0a74b12a1cf9cfbbf16d4ca.md
+++ b/.changelog/e83abffbd0a74b12a1cf9cfbbf16d4ca.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/ea45fe577c19473db9fda16579cd8ac6.md
+++ b/.changelog/ea45fe577c19473db9fda16579cd8ac6.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/ea630ea9d53a46aa872e8d6aeb7fe98a.md
+++ b/.changelog/ea630ea9d53a46aa872e8d6aeb7fe98a.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.1.0 - 2026-04-03
+
+Minor:
+* Omit trailing . from entries to match the requirement that names end in an alphanumeric character, per the manpage/spec. Previous behavior of trailing dots is available with remove_trailing_dots=False - [#43](https://github.com/octodns/octodns-etchosts/pull/43)
+
+Patch:
+* Use new [changelet](https://github.com/octodns/changelet) tooling - [#42](https://github.com/octodns/octodns-etchosts/pull/42)
+
 ## v1.0.0 - 2025-05-04 - Long overdue 1.0
 
 * Address pending octoDNS 2.x deprecations, require minimum of 1.5.x

--- a/octodns_etchosts/__init__.py
+++ b/octodns_etchosts/__init__.py
@@ -11,7 +11,7 @@ from os.path import isdir
 from octodns.provider.base import BaseProvider
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '1.0.0'
+__version__ = __VERSION__ = '1.1.0'
 
 
 def _wildcard_match(fqdn, wildcards):


### PR DESCRIPTION
## 1.1.0 - 2026-04-03

Minor:
* Omit trailing . from entries to match the requirement that names end in an alphanumeric character, per the manpage/spec. Previous behavior of trailing dots is available with remove_trailing_dots=False - [#43](https://github.com/octodns/octodns-etchosts/pull/43)

Patch:
* Use new [changelet](https://github.com/octodns/changelet) tooling - [#42](https://github.com/octodns/octodns-etchosts/pull/42)

